### PR TITLE
chore: 🐝 Update SDK - Generate 0.0.6

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,4 +1,9 @@
 
+<div align="center">
+    <a href="https://codespaces.new/criblio/cribl-cloud-management-sdk-typescript.git/tree/main"><img src="https://github.com/codespaces/badge.svg" /></a>
+</div>
+<br>
+
 > **Remember to shutdown a GitHub Codespace when it is not in use!**
 
 # Dev Containers Quick Start

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,10 @@ management:
   docVersion: 0.0.1
   speakeasyVersion: 1.596.1
   generationVersion: 2.672.0
-  releaseVersion: 0.0.5
-  configChecksum: d78db6d33751243a4d00084eb31f5168
+  releaseVersion: 0.0.6
+  configChecksum: 8be6cccb77d2fb22698e41670f5c8601
+  repoURL: https://github.com/criblio/cribl-cloud-management-sdk-typescript.git
+  installationURL: https://github.com/criblio/cribl-cloud-management-sdk-typescript
   published: true
 features:
   typescript:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.0.5
+  version: 0.0.6
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -6,6 +6,7 @@ sources:
         sourceBlobDigest: sha256:363736ad848e333c5fe50280ed71764efe2a0960f500a413b23d8b63077569c0
         tags:
             - latest
+            - speakeasy-sdk-regen-1752657756
             - 0.0.1
 targets:
     cribl-mgmt-plane:
@@ -14,7 +15,7 @@ targets:
         sourceRevisionDigest: sha256:464359f5f9a97b37ea4ee3360aa3063985d6ba8a64ff82881bc7f0a2c5132abc
         sourceBlobDigest: sha256:363736ad848e333c5fe50280ed71764efe2a0960f500a413b23d8b63077569c0
         codeSamplesNamespace: cribl-cloud-management-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:dc3f6a7d7c19d4a80c522a4d245e44c578243ba17e7984bde2316e4e7899e279
+        codeSamplesRevisionDigest: sha256:23f9a0b250bb4f3ecb4d5b8dccdb33da741e87503fe90d7ccee44b56d090e1c4
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.596.1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,11 @@
+
+
+## 2025-08-06 01:55:45
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.596.1 (2.672.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v0.0.6] .
+### Releases
+- [NPM v0.0.6] https://www.npmjs.com/package/cribl-mgmt-plane/v/0.0.6 - .

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "cribl-mgmt-plane",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "zod": "^3.20.0"
       },

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "cribl-mgmt-plane",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cribl-mgmt-plane",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cribl-mgmt-plane",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "zod": "^3.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cribl-mgmt-plane",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Speakeasy",
   "type": "module",
   "tshy": {
@@ -18,6 +18,10 @@
     }
   },
   "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/criblio/cribl-cloud-management-sdk-typescript.git"
+  },
   "scripts": {
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tshy",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -58,7 +58,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "0.0.1",
-  sdkVersion: "0.0.5",
+  sdkVersion: "0.0.6",
   genVersion: "2.672.0",
-  userAgent: "speakeasy-sdk/typescript 0.0.5 2.672.0 0.0.1 cribl-mgmt-plane",
+  userAgent: "speakeasy-sdk/typescript 0.0.6 2.672.0 0.0.1 cribl-mgmt-plane",
 } as const;


### PR DESCRIPTION
> [!IMPORTANT]
> Linting report available at: <https://app.speakeasy.com/org/cribl/cribl/linting-report/af15647219a8980f4f7ba5805cf92709>
> OpenAPI Change report available at: <https://app.speakeasy.com/org/cribl/cribl/changes-report/41dc7d242b1a8ee20da89cb1055a8612>
# SDK update
Based on:
- OpenAPI Doc  
- Speakeasy CLI 1.596.1 (2.672.0) https://github.com/speakeasy-api/speakeasy
## Versioning

Version Bump Type: [patch] - 🤖 (automated)
## OpenAPI Change Summary
No specification changes

## TYPESCRIPT CHANGELOG
No relevant generator changes

